### PR TITLE
Pass along hook.ident when breakpoint hits

### DIFF
--- a/lib/andbug/vm.py
+++ b/lib/andbug/vm.py
@@ -787,7 +787,7 @@ class Session(object):
             with self.ectl:
                 hook = self.emap.get(evt[0])
             if hook is not None:
-                hook.put(evt[1:])
+                hook.put(evt[1:] + evt[0:1])
                           
     def load_classes(self):
         code, buf = self.conn.request(0x0114)


### PR DESCRIPTION
Having access to hook.ident once hook.func gets invoked can be necessary.

Here hook.ident is appended at the end of the argument list. This should break the fewest callbacks. For example, the ./andbug shell break command works unmodified.
